### PR TITLE
[WIP] Disable the zypper lock when running the provisioner

### DIFF
--- a/spec/lib/clients/auto_client_spec.rb
+++ b/spec/lib/clients/auto_client_spec.rb
@@ -35,10 +35,16 @@ describe Yast::CM::AutoClient do
   end
 
   describe "#write" do
+    let(:zypp_pid) { described_class.const_get("ZYPP_PID") }
+    let(:zypp_pid_backup) { described_class.const_get("ZYPP_PID_BACKUP") }
+
     before do
       allow(Yast::CM::Provisioner).to receive(:provisioner_for)
         .with(profile["type"], any_args)
         .and_return(provisioner)
+      allow(Yast::UI).to receive(:TimeoutUserInput).and_return(:ok)
+      allow(provisioner).to receive(:run)
+      allow(zypp_pid).to receive(:exist?).and_return(false)
       client.import(profile)
     end
 
@@ -46,6 +52,19 @@ describe Yast::CM::AutoClient do
       expect(Yast::UI).to receive(:TimeoutUserInput).and_return(:ok)
       expect(provisioner).to receive(:run)
       client.write
+    end
+
+    context "when zypp is locked" do
+      before do
+        allow(zypp_pid).to receive(:exist?).and_return(true)
+        allow(zypp_pid_backup).to receive(:exist?).and_return(true)
+      end
+
+      it "moves and restores the zypp lock" do
+        expect(::FileUtils).to receive(:mv).with(zypp_pid, zypp_pid_backup)
+        expect(::FileUtils).to receive(:mv).with(zypp_pid_backup, zypp_pid)
+        client.write
+      end
     end
   end
 end


### PR DESCRIPTION
To install packages with Salt/Puppet, we need the zypper lock to be disabled. Maybe we would need to refresh repositories after restoring the zypp lock again.